### PR TITLE
Cleaning up command help output

### DIFF
--- a/lib/clik/output/formatters/command_help.ex
+++ b/lib/clik/output/formatters/command_help.ex
@@ -18,15 +18,19 @@ defmodule Clik.Output.Formatters.CommandHelp do
 
     doc = Document.text(doc, "USAGE: #{Platform.script_name()} #{command.name}")
 
+    filtered = Map.delete(config.global_options, :help)
+
     global_options =
-      Enum.map(config.global_options, fn {_key, option} -> Options.format_name(option) end)
+      Enum.map(filtered, fn {_key, option} -> Options.format_name(option) end)
       |> Enum.join(" ")
+      |> String.trim_leading()
 
     command_options =
       Enum.map(Command.options(command), fn {_, option} -> Options.format_name(option) end)
       |> Enum.join(" ")
+      |> String.trim_leading()
 
-    doc = Document.line(doc, " #{global_options} #{command_options}")
+    doc = Document.line(doc, "#{global_options} #{command_options}")
 
     global_flags =
       Enum.reduce(config.global_options, Table.empty(), fn {_, option}, flags ->

--- a/test/data/formatted_help_8.txt
+++ b/test/data/formatted_help_8.txt
@@ -1,5 +1,5 @@
 Says hello to the world
-USAGE: mix default  -h  --verbose
+USAGE: mix default --verbose
 
 Global options
 --------------


### PR DESCRIPTION
Remove `-h` from usage to reduce visual noise.